### PR TITLE
Tweak ship and weapon data

### DIFF
--- a/data/hulls/vppps_balteus.ship
+++ b/data/hulls/vppps_balteus.ship
@@ -17,6 +17,7 @@
     "shieldRadius": 183.5,
     "viewOffset": 0,
     "builtInMods": [
+        "vppps_pdi",
         "pointdefenseai"
     ],
     "builtInWings": [],

--- a/data/hulls/vppps_caelestis.ship
+++ b/data/hulls/vppps_caelestis.ship
@@ -17,7 +17,7 @@
     "shieldRadius": 250,
     "viewOffset": 0,
     "builtInMods": [
-        "distributed_fire_control",
+        "advancedcore",
         "missleracks",
         "pointdefenseai"
     ],
@@ -30,7 +30,7 @@
             "type": "ENERGY",
             "mount": "TURRET",
             "arc": 210,
-            "angle": 0,
+            "angle": -30,
             "locations": [
                      143,      -91
             ]
@@ -41,7 +41,7 @@
             "type": "ENERGY",
             "mount": "TURRET",
             "arc": 210,
-            "angle": 0,
+            "angle": 30,
             "locations": [
                      143,       91
             ]

--- a/data/weapons/proj/vppps_proxy_mine_shot.proj
+++ b/data/weapons/proj/vppps_proxy_mine_shot.proj
@@ -1,7 +1,6 @@
 {
   "id": "vppps_proxy_mine_shot",
   "specClass": "projectile",
-  "onFireEffect": "com.fs.starfarer.api.impl.combat.HeavyAdjudicatorEffect",
   "spawnType": "BALLISTIC",
   "collisionClass": "PROJECTILE_FF",
   "collisionClassByFighter": "PROJECTILE_FIGHTER",

--- a/data/weapons/weapon_data.csv
+++ b/data/weapons/weapon_data.csv
@@ -1,4 +1,4 @@
 name,id,tier,rarity,base value,range,damage/second,damage/shot,emp,impact,turn rate,OPs,ammo,ammo/sec,reload size,type,energy/shot,energy/second,chargeup,chargedown,burst size,burst delay,min spread,max spread,spread/shot,spread decay/sec,beam speed,proj speed,launch speed,flight time,proj hitpoints,autofireAccBonus,extraArcForAI,hints,tags,groupTag,tech/manufacturer,for weapon tooltip>>,primaryRoleStr,speedStr,trackingStr,turnRateStr,accuracyStr,customPrimary,customPrimaryHL,customAncillary,customAncillaryHL,noDPSInTooltip,number
 Cold Electron Cannon,vppps_cold_electron,2,,4000,1000,150,,200,10,20,12,,,,KINETIC,,150,0.1,0.1,,,,,,,10000,,,,,,,FIRE_WHEN_INEFFICIENT,beam10,,,,Suppression,,,,,,,,,,
-Gamma Ray Projector,vppps_gamma_ray,2,,10000,800,1200,,800,,10,30,,,,HIGH_EXPLOSIVE,,400,0.2,0.1,,,,,,,10000,,,,,,,,beam20,,,,Anti-Armor,,,,,,,,,,
-Proxy Mine Rail,vppps_proxymine_large,3,,12000,1000,,800,,50,16,20,,,,FRAGMENTATION,60,,0.1,0.15,1,0,0,0,0,10,,1500,,,300,,,"PD,PD_ALSO",he20,,,,Anti-Armor (Area),,,,,,,,,,
+Gamma Ray Projector,vppps_gamma_ray,3,,10000,800,800,,800,5,10,30,,,,HIGH_EXPLOSIVE,,500,0.2,0.1,,,,,,,10000,,,,,,,,beam20,,,,Anti-Armor,,,,,,,,,,
+Proxy Mine Rail,vppps_proxymine_large,3,,12000,1000,,600,,50,16,30,,,,FRAGMENTATION,120,,0.23,0.1,1,0,0,0,0,10,,1500,,,300,,,"PD,PD_ALSO",he20,,,,Anti-Armor (Area),,,,,,,,,,


### PR DESCRIPTION
Ship data changes:
- Balteus
   - Added Point-Defense Integration
- Caelestis
   - Changed the Distributed Fire Control to Advanced Targeting Core
   - Angled the front small turrets to 30 degrees on each either side instead of 0.

Weapon data changes:
- Proxy Mine Rail
   - Removed the Adjudicator fire effect.
   - Damage 800 -> 600
   - OP 20 -> 30
   - Flux per shot doubled (60 -> 120)
   - Refire delay changed from 0.25 to 0.33 (3 shots per second instead of 4)
- Gamma Ray Projector
   - Damage 1200 -> 800
   - Flux per second 400 -> 500